### PR TITLE
This is the basic dockerfile that I'm using for alertmanager-irc-relay

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.16
+
+WORKDIR /go/src/app
+COPY . .
+
+RUN go get -d -v ./...
+RUN go install -v ./...
+
+CMD ["alertmanager-irc-relay", "--config=/config.yml"]


### PR DESCRIPTION
This is the basic dockerfile that I'm using for alertmanager-irc-relay.

I figured it might be useful to include upstream.
