### PR TITLE
Allow customized NickServ and ChanServ

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ http_port: 8000
 # Connect to this IRC host/port.
 #
 # Note: SSL is enabled by default, use "irc_use_ssl: no" to disable.
+# Set "irc_verify_ssl: no" to accept invalid SSL certificates (not recommended)
 irc_host: irc.example.com
 irc_port: 7000
 # Optionally set the server password
@@ -75,6 +76,11 @@ nickserv_identify_patterns:
   - "identify via /msg NickServ identify <password>"
   - "type /msg NickServ IDENTIFY password"
   - "authenticate yourself to services with the IDENTIFY command"
+
+# Rarely NickServ or ChanServ is reached at a specific hostname.  Specify an
+# override here
+nickserv_name: NickServ
+chanserv_name: ChanServ
 ```
 
 Running the bot (assuming *$GOPATH* and *$PATH* are properly setup for go):

--- a/config.go
+++ b/config.go
@@ -49,7 +49,9 @@ type Config struct {
 	UsePrivmsg      bool         `yaml:"use_privmsg"`
 	AlertBufferSize int          `yaml:"alert_buffer_size"`
 
+	NickservName    string       `yaml:"nickserv_name"`
 	NickservIdentifyPatterns []string `yaml:"nickserv_identify_patterns"`
+	ChanservName    string       `yaml:"chanserv_name"`
 }
 
 func LoadConfig(configFile string) (*Config, error) {
@@ -68,12 +70,14 @@ func LoadConfig(configFile string) (*Config, error) {
 		MsgOnce:         false,
 		UsePrivmsg:      false,
 		AlertBufferSize: 2048,
+		NickservName:    "NickServ",
 		NickservIdentifyPatterns: []string{
 			"Please choose a different nickname, or identify via",
 			"identify via /msg NickServ identify <password>",
 			"type /msg NickServ IDENTIFY password",
 			"authenticate yourself to services with the IDENTIFY command",
 		},
+		ChanservName:    "ChanServ",
 	}
 
 	if configFile != "" {

--- a/irc.go
+++ b/irc.go
@@ -82,6 +82,7 @@ type IRCNotifier struct {
 	Nick         string
 	NickPassword string
 
+	NickservName string
 	NickservIdentifyPatterns []string
 
 	Client    *irc.Conn
@@ -121,6 +122,7 @@ func NewIRCNotifier(config *Config, alertMsgs chan AlertMsg, delayerMaker Delaye
 	notifier := &IRCNotifier{
 		Nick:                     config.IRCNick,
 		NickPassword:             config.IRCNickPass,
+		NickservName:             config.NickservName,
 		NickservIdentifyPatterns: config.NickservIdentifyPatterns,
 		Client:                   client,
 		AlertMsgs:                alertMsgs,
@@ -187,7 +189,7 @@ func (n *IRCNotifier) HandleNickservMsg(msg string) {
 		logging.Debug("Checking if NickServ message matches identify request '%s'", identifyPattern)
 		if strings.Contains(cleanedMsg, identifyPattern) {
 			logging.Info("Handling NickServ request to IDENTIFY")
-			n.Client.Privmsgf("NickServ", "IDENTIFY %s", n.NickPassword)
+			n.Client.Privmsgf(n.NickservName, "IDENTIFY %s", n.NickPassword)
 			return
 		}
 	}
@@ -203,7 +205,7 @@ func (n *IRCNotifier) MaybeGhostNick() {
 	if currentNick != n.Nick {
 		logging.Info("My nick is '%s', sending GHOST to NickServ to get '%s'",
 			currentNick, n.Nick)
-		n.Client.Privmsgf("NickServ", "GHOST %s %s", n.Nick,
+		n.Client.Privmsgf(n.NickservName, "GHOST %s %s", n.Nick,
 			n.NickPassword)
 		time.Sleep(n.NickservDelayWait)
 

--- a/irc_test.go
+++ b/irc_test.go
@@ -42,6 +42,8 @@ func makeTestIRCConfig(IRCPort int) *Config {
 		NickservIdentifyPatterns: []string{
 			"identify yourself ktnxbye",
 		},
+		NickservName:    "NickServ",
+		ChanservName:    "ChanServ",
 	}
 }
 


### PR DESCRIPTION
DALnet requires interacting with NickServ@services.dal.net and ChanServ@services.dal.net instead of the traditional server-local NickServ and ChanServ.  This PR allows setting the custom values.