### PR TITLE
Add option for resolved template

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ use_privmsg: yes
 #
 # The formatting is based on golang's text/template .
 msg_template: "Alert {{ .Labels.alertname }} on {{ .Labels.instance }} is {{ .Status }}"
+# By default, firing and resolved messages use the template defined as msg_template.
+# Define msg_template_resolved to define a different template for resolved messages.
+# msg_template_resolved: "Resolved: {{ .Labels.alertname }} on {{ .Labels.instance }}"
 # Note: When sending only one message per alert group the default
 # msg_template is set to
 # "Alert {{ .GroupLabels.alertname }} for {{ .GroupLabels.job }} is {{ .Status }}"

--- a/config.go
+++ b/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	IRCVerifySSL    bool         `yaml:"irc_verify_ssl"`
 	IRCChannels     []IRCChannel `yaml:"irc_channels"`
 	MsgTemplate     string       `yaml:"msg_template"`
+	MsgTemplateResolved string   `yaml:"msg_template_resolved"`
 	MsgOnce         bool         `yaml:"msg_once_per_alert_group"`
 	UsePrivmsg      bool         `yaml:"use_privmsg"`
 	AlertBufferSize int          `yaml:"alert_buffer_size"`
@@ -98,6 +99,9 @@ func LoadConfig(configFile string) (*Config, error) {
 		} else {
 			config.MsgTemplate = defaultMsgTemplate
 		}
+	}
+	if config.MsgTemplateResolved == "" {
+		config.MsgTemplateResolved = config.MsgTemplate
 	}
 
 	loadedConfig, _ := yaml.Marshal(config)

--- a/format_test.go
+++ b/format_test.go
@@ -133,3 +133,20 @@ func TestMultilineTemplates(t *testing.T) {
 
 	CreateFormatterAndCheckOutput(t, &testingConfig, expectedAlertMsgs)
 }
+
+func TestResolvedTemplate(t *testing.T) {
+	testingConfig := Config{
+		MsgTemplateResolved: "Resolved: {{ .Labels.alertname }}",
+	}
+	expectedAlertMsgs := []AlertMsg{
+		AlertMsg{
+			Channel: "#somechannel",
+			Alert:   "Resolved: airDown",
+		},
+		AlertMsg{
+			Channel: "#somechannel",
+			Alert:   "Resolved: airDown",
+		},
+	}
+	CreateFormatterAndCheckOutput(t, &testingConfig, expectedAlertMsgs)
+}


### PR DESCRIPTION
This introduces a "msg_template_resolved" option, allowing a custom template for resolved messages to be defined. If the option is not set, the existing "msg_template" will apply as before. This allows users to define different templates for firing and resolved events.